### PR TITLE
Create missing target dir in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::fs;
 
 fn main() {
+    fs::create_dir_all("target").expect("Unable to create target directory");
     fs::write("target/schema.sdl", fuel_core_client::SCHEMA_SDL)
         .expect("Unable to write schema file");
 


### PR DESCRIPTION
This was preventing the `build.rs` from succeeding when used as a git dependency. Path dependency still works, which is how I missed this bug.